### PR TITLE
Fix readme

### DIFF
--- a/src/README.md
+++ b/src/README.md
@@ -5,7 +5,7 @@ tags:
   - provider/aws
 ---
 
-# Component: `glue`
+# Component: `glue-crawler`
 
 This component provisions Glue crawlers.
 


### PR DESCRIPTION
## what
- Copy CHANGELOG.md to `src/CHANGELOG.md`
- Generate `src/README.md` from `README.yaml`

## why
- `atmos vendor` should get readme files
